### PR TITLE
temp fixes for opencv3 with qt support

### DIFF
--- a/image_view/CMakeLists.txt
+++ b/image_view/CMakeLists.txt
@@ -42,7 +42,7 @@ if(ANDROID)
 endif()
 
 find_package(GTK2)
-add_definitions(-DHAVE_GTK)
+#add_definitions(-DHAVE_GTK)
 include_directories(SYSTEM ${GTK2_INCLUDE_DIRS})
 
 # Nodelet library

--- a/image_view/src/nodelets/disparity_nodelet.cpp
+++ b/image_view/src/nodelets/disparity_nodelet.cpp
@@ -99,7 +99,7 @@ void DisparityNodelet::onInit()
   bool autosize;
   local_nh.param("autosize", autosize, false);
 
-  cv::namedWindow(window_name_, autosize ? cv::WND_PROP_AUTOSIZE : 0);
+  //cv::namedWindow(window_name_, autosize ? cv::WND_PROP_AUTOSIZE : 0);
 #if OPENCV3
 #else
 #ifdef HAVE_GTK
@@ -166,6 +166,7 @@ void DisparityNodelet::imageCb(const stereo_msgs::DisparityImageConstPtr& msg)
 #endif
   
   cv::imshow(window_name_, disparity_color_);
+  cv::waitKey(1);
 }
 
 unsigned char DisparityNodelet::colormap[768] =

--- a/image_view/src/nodelets/image_nodelet.cpp
+++ b/image_view/src/nodelets/image_nodelet.cpp
@@ -133,9 +133,9 @@ void ImageNodelet::onInit()
   local_nh.param("filename_format", format_string, std::string("frame%04i.jpg"));
   filename_format_.parse(format_string);
 
-  cv::namedWindow(window_name_, autosize ? cv::WND_PROP_AUTOSIZE : 0);
-  cv::setMouseCallback(window_name_, &ImageNodelet::mouseCb, this);
-  
+  //cv::namedWindow(window_name_, autosize ? cv::WND_PROP_AUTOSIZE : 0);
+  //cv::setMouseCallback(window_name_, &ImageNodelet::mouseCb, this);
+
 #ifdef HAVE_GTK
   // Register appropriate handler for when user closes the display window
   GtkWidget *widget = GTK_WIDGET( cvGetWindowHandle(window_name_.c_str()) );
@@ -184,8 +184,10 @@ void ImageNodelet::imageCb(const sensor_msgs::ImageConstPtr& msg)
   // Must release the mutex before calling cv::imshow, or can deadlock against
   // OpenCV's window mutex.
   image_mutex_.unlock();
-  if (!last_image_.empty())
+  if (!last_image_.empty()){
     cv::imshow(window_name_, last_image_);
+    cv::waitKey(1);
+  }
 }
 
 void ImageNodelet::mouseCb(int event, int x, int y, int flags, void* param)
@@ -202,7 +204,7 @@ void ImageNodelet::mouseCb(int event, int x, int y, int flags, void* param)
   }
   if (event != cv::EVENT_RBUTTONDOWN)
     return;
-  
+
   boost::lock_guard<boost::mutex> guard(this_->image_mutex_);
 
   const cv::Mat &image = this_->last_image_;


### PR DESCRIPTION
ros-indigo-opencv3 package is compiled with qt support instead of standard gtk. So a few temp changes needed to be done in order to get image_view and disparity_view working.
This changes will get obsolete by the time opencv3 ros package get compiled against gtk